### PR TITLE
feat(EA-2444): Upgrade stratus to have an optional param to close testrail Milestone

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ The project ID of the TestRail project.
 ##### `suite_id` (**Required**)
 The suite ID of the TestRail project. Does not include "S" prefix.
 
-##### `exclude_e2e` (**Optional**)
-Used in projects that don't require nightwatch testing like in EDS. When true will close milestones regardless of E2E reports.
+##### `close_milestone` (**Optional**)
+Make sure testrail milestone will get closed after production pipeline is completed.
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ The project ID of the TestRail project.
 ##### `suite_id` (**Required**)
 The suite ID of the TestRail project. Does not include "S" prefix.
 
+##### `exclude_e2e` (**Optional**)
+Used in projects that don't require nightwatch testing like in EDS. When true will close milestones regardless of E2E reports.
+
 ## Outputs
 
 ##### `run_id`

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,11 @@ inputs:
     required: false
     description: A boolean to report results to the presenter
     default: "false"
+  exclude_e2e:
+    description: Used in projects that don't require nightwatch testing like in EDS. When true will close milestones regardless of E2E reports.
+    required: false
+    type: boolean
+    default: false
 outputs:
   test_runs:
     value: ${{ steps.report.outputs.test_runs }}
@@ -54,7 +59,7 @@ runs:
       with:
         repository: q4mobile/stratus-testrail-reporter
         path: ./.github/actions/stratus-testrail-reporter
-        ref: v12.1
+        ref: v12.2
 
     - uses: ./.github/actions/stratus-testrail-reporter/main
       id: report
@@ -68,6 +73,7 @@ runs:
         project_id: ${{ inputs.project_id }}
         suite_id: ${{ inputs.suite_id }}
         jira_key: ${{ steps.jira-key-match.outputs.match }}
+        exclude_e2e: ${{ inputs.exclude_e2e }}
 
     - if: inputs.report_results == 'true'
       id: result

--- a/action.yml
+++ b/action.yml
@@ -26,8 +26,8 @@ inputs:
     required: false
     description: A boolean to report results to the presenter
     default: "false"
-  exclude_e2e:
-    description: Used in projects that don't require nightwatch testing like in EDS. When true will close milestones regardless of E2E reports.
+  close_milestone:
+    description: Make sure testrail milestone will get closed after production pipeline is completed.
     required: false
     type: boolean
     default: false
@@ -73,7 +73,7 @@ runs:
         project_id: ${{ inputs.project_id }}
         suite_id: ${{ inputs.suite_id }}
         jira_key: ${{ steps.jira-key-match.outputs.match }}
-        exclude_e2e: ${{ inputs.exclude_e2e }}
+        close_milestone: ${{ inputs.close_milestone }}
 
     - if: inputs.report_results == 'true'
       id: result

--- a/main/action.yml
+++ b/main/action.yml
@@ -23,6 +23,11 @@ inputs:
   suite_id:
     required: false
     description: The suite ID of the Testrail project
+  exclude_e2e:
+    description: Used in projects that don't require nightwatch testing like in EDS. When true will close milestones regardless of E2E reports.
+    required: false
+    type: boolean
+    default: false
 outputs:
   test_runs:
     description: The result of the test runs

--- a/main/action.yml
+++ b/main/action.yml
@@ -23,8 +23,8 @@ inputs:
   suite_id:
     required: false
     description: The suite ID of the Testrail project
-  exclude_e2e:
-    description: Used in projects that don't require nightwatch testing like in EDS. When true will close milestones regardless of E2E reports.
+  close_milestone:
+    description: Make sure testrail milestone will get closed after production pipeline is completed.
     required: false
     type: boolean
     default: false

--- a/src/run/run.definition.ts
+++ b/src/run/run.definition.ts
@@ -16,6 +16,7 @@ export enum InputKey {
   TargetBranch = "target_branch",
   ProjectId = "project_id",
   SuiteId = "suite_id",
+  ExcludeE2E = "exclude_e2e",
 }
 
 export type TestRunConfig = {

--- a/src/run/run.definition.ts
+++ b/src/run/run.definition.ts
@@ -16,7 +16,7 @@ export enum InputKey {
   TargetBranch = "target_branch",
   ProjectId = "project_id",
   SuiteId = "suite_id",
-  ExcludeE2E = "exclude_e2e",
+  CloseMilestone = "close_milestone",
 }
 
 export type TestRunConfig = {

--- a/src/run/run.ts
+++ b/src/run/run.ts
@@ -8,7 +8,7 @@ import findDuplicates from "../utils/findDuplicate";
 
 const environment = process.env.NODE_ENV || "debug";
 export async function run(): Promise<void> {
-  const excludeE2E = getBooleanInput(InputKey.ExcludeE2E);
+  const closeMilestone = getBooleanInput(InputKey.CloseMilestone);
   const jiraKey = getInput(InputKey.JiraKey);
   const regressionMode = getBooleanInput(InputKey.RegressionMode);
   const projectId = parseInt(getInput(InputKey.ProjectId), 10);
@@ -29,13 +29,13 @@ export async function run(): Promise<void> {
       testRunConfigs = await getTrunkTestRunConfigs();
 
       for (const testRun of testRunConfigs) {
-        await reportToTestrail(excludeE2E, jiraKey, trunkMode, regressionMode, testRun, testRailOptions);
+        await reportToTestrail(closeMilestone, jiraKey, trunkMode, regressionMode, testRun, testRailOptions);
       }
     } else {
       testRunConfigs = [{ projectId: projectId, suiteId: suiteId }];
 
       await reportToTestrail(
-        excludeE2E,
+        closeMilestone,
         jiraKey,
         trunkMode,
         regressionMode,
@@ -52,7 +52,7 @@ export async function run(): Promise<void> {
 }
 
 async function reportToTestrail(
-  excludeE2E: boolean,
+  closeMilestone: boolean,
   jiraKey: string,
   trunkMode: boolean,
   regressionMode: boolean,
@@ -144,7 +144,7 @@ async function reportToTestrail(
     });
   }
 
-  if (environment === Environment.Production && (suite.name.includes("E2E") || excludeE2E)) {
+  if (environment === Environment.Production && (suite.name.includes("E2E") || closeMilestone)) {
     await testrailService.closeMilestone(milestone.id).catch((error) => {
       setFailed("The TestRail Milestone could not be closed.");
       throw error;

--- a/src/run/run.ts
+++ b/src/run/run.ts
@@ -8,6 +8,7 @@ import findDuplicates from "../utils/findDuplicate";
 
 const environment = process.env.NODE_ENV || "debug";
 export async function run(): Promise<void> {
+  const excludeE2E = getBooleanInput(InputKey.ExcludeE2E);
   const jiraKey = getInput(InputKey.JiraKey);
   const regressionMode = getBooleanInput(InputKey.RegressionMode);
   const projectId = parseInt(getInput(InputKey.ProjectId), 10);
@@ -28,12 +29,13 @@ export async function run(): Promise<void> {
       testRunConfigs = await getTrunkTestRunConfigs();
 
       for (const testRun of testRunConfigs) {
-        await reportToTestrail(jiraKey, trunkMode, regressionMode, testRun, testRailOptions);
+        await reportToTestrail(excludeE2E, jiraKey, trunkMode, regressionMode, testRun, testRailOptions);
       }
     } else {
       testRunConfigs = [{ projectId: projectId, suiteId: suiteId }];
 
       await reportToTestrail(
+        excludeE2E,
         jiraKey,
         trunkMode,
         regressionMode,
@@ -50,6 +52,7 @@ export async function run(): Promise<void> {
 }
 
 async function reportToTestrail(
+  excludeE2E: boolean,
   jiraKey: string,
   trunkMode: boolean,
   regressionMode: boolean,
@@ -141,7 +144,7 @@ async function reportToTestrail(
     });
   }
 
-  if (environment === Environment.Production && suite.name.includes("E2E")) {
+  if (environment === Environment.Production && (suite.name.includes("E2E") || excludeE2E)) {
     await testrailService.closeMilestone(milestone.id).catch((error) => {
       setFailed("The TestRail Milestone could not be closed.");
       throw error;


### PR DESCRIPTION
It was identified that only projects with E2E tests have their milestone closed automatically, this happens because of the following condition in `src/run/run.ts`.
```
if (environment === Environment.Production && suite.name.includes("E2E")) {
```
to overcome this problem a new parameter was created called `exclude_e2e` with default value equals `false`, this will allow projects without E2E test like EDS's to ignore the missing E2E suite and close the milestone anyway.
```
if (environment === Environment.Production && (suite.name.includes("E2E") || excludeE2E)) {
```